### PR TITLE
Update the my-executor def for changes in core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
+                 [org.clojure/core.async "0.4.500"]]
   :repl-options {:init-ns lispcast-clojure-core-async.core})

--- a/src/lispcast_clojure_core_async/factory.clj
+++ b/src/lispcast_clojure_core_async/factory.clj
@@ -8,12 +8,16 @@
 ;; increase the size of the thread pool
 
 (defonce my-executor
-  (java.util.concurrent.Executors/newFixedThreadPool
-   1000
-   (conc/counted-thread-factory "toy-car-factory-%d" true)))
+         (let [executor-svc (Executors/newFixedThreadPool
+                              1
+                              (conc/counted-thread-factory "toy-car-factory-%d" true))]
+           (reify protocols/Executor
+             (protocols/exec [this r]
+               (.execute executor-svc ^Runnable r)))))
 
 (alter-var-root #'clojure.core.async.impl.dispatch/executor
-                (constantly (delay (tp/thread-pool-executor my-executor))))
+                (constantly (delay my-executor)))
+
 
 ;; define our factory operations
 


### PR DESCRIPTION
HI @ericnormand,

I was trying to get the examples working but `cursive` kept raising the `wrong arity` alarm for `tconc/counted-thread-factory` and after some googling I found a solution below which also tell at exactly which commit this behaviour changed. 

Hope this helps others get unstuck :) 

Here's the reference 

https://stackoverflow.com/questions/18779296/clojure-core-async-any-way-to-control-number-of-threads-in-that-go-thread